### PR TITLE
Install the packages early on

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem@lettron.fr'
 license 'Apache 2.0'
 description 'Installs/Configures the Ceph distributed filesystem'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.9.13'
+version '0.9.14'
 
 depends	'apache2', '>= 1.1.12'
 depends 'apt'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,9 +1,10 @@
 include_recipe 'ceph::repo' if node['ceph']['install_repo']
-include_recipe 'ceph::conf'
 
 # Tools needed by cookbook
 node['ceph']['packages'].each do |pck|
   package pck
 end
+
+include_recipe 'ceph::conf'
 
 chef_gem 'netaddr'


### PR DESCRIPTION
Parts of the conf recipe reference the "ceph" user, which comes from the
package.  Therefore, the packages need to be installed before running
the conf recipe.