### PR TITLE
Use UID instead of name for chown

### DIFF
--- a/recipes/conf.rb
+++ b/recipes/conf.rb
@@ -8,8 +8,8 @@ unless node['ceph']['config']['fsid']
 end
 
 directory '/etc/ceph' do
-  owner 'ceph'
-  group 'ceph'
+  owner '64045'
+  group '64045'
   mode '0755'
   action :create
 end
@@ -22,7 +22,7 @@ template '/etc/ceph/ceph.conf' do
       :is_rgw => node['ceph']['is_radosgw']
     }
   }
-  owner 'ceph'
-  group 'ceph'
+  owner '64045'
+  group '64045'
   mode '0644'
 end


### PR DESCRIPTION
When chown-ing files/folder (during ceph::conf), use the UID instead of
the name.  This should fix a race condition we're seeing between package
installs and config file deploys.