### PR TITLE
Revert "Use UID instead of name for chown"

### DIFF
--- a/recipes/conf.rb
+++ b/recipes/conf.rb
@@ -8,8 +8,8 @@ unless node['ceph']['config']['fsid']
 end
 
 directory '/etc/ceph' do
-  owner '64045'
-  group '64045'
+  owner 'ceph'
+  group 'ceph'
   mode '0755'
   action :create
 end
@@ -22,7 +22,7 @@ template '/etc/ceph/ceph.conf' do
       :is_rgw => node['ceph']['is_radosgw']
     }
   }
-  owner '64045'
-  group '64045'
+  owner 'ceph'
+  group 'ceph'
   mode '0644'
 end


### PR DESCRIPTION
Reverts fzylogic/ceph-cookbook#5