### PR TITLE
install packages before conf

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem@lettron.fr'
 license 'Apache 2.0'
 description 'Installs/Configures the Ceph distributed filesystem'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.9.16'
+version '0.9.17'
 
 depends	'apache2', '>= 1.1.12'
 depends 'apt'

--- a/recipes/conf.rb
+++ b/recipes/conf.rb
@@ -1,5 +1,7 @@
 # fail 'mon_initial_members must be set in config' if node['ceph']['config']['mon_initial_members'].nil?
 
+include_recipe 'ceph'
+
 unless node['ceph']['config']['fsid']
   Chef::Log.warn('We are genereting a new uuid for fsid')
   require 'securerandom'


### PR DESCRIPTION
Packages must be installed before ceph::conf is called.  ceph::conf
references the ceph user, which comes from the package and as such, will
never be able to complete unless the packages are installed first.