### PR TITLE
Set owner/group default attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,9 @@
 default['ceph']['install_debug'] = false
 default['ceph']['encrypted_data_bags'] = false
 
+default['ceph']['owner'] = 'ceph'
+default['ceph']['group'] = 'ceph'
+
 default['ceph']['install_repo'] = true
 
 default['ceph']['user_pools'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem@lettron.fr'
 license 'Apache 2.0'
 description 'Installs/Configures the Ceph distributed filesystem'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.9.17'
+version '0.9.18'
 
 depends	'apache2', '>= 1.1.12'
 depends 'apt'


### PR DESCRIPTION
Setting ceph:ceph for the default user/group.  This should help file/dir
ownership during install/setup.